### PR TITLE
Add `AxisTick`, `AxisValue`, and `AxisValueLabel`

### DIFF
--- a/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
+++ b/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
@@ -242,50 +242,50 @@ extension AxisMarkPosition: AttributeDecodable {
 /// Possible values:
 /// * `automatic`
 ///   * Additional Attributes
-///     * `values-minimum-stride` (number)
-///     * `values-desired-count` (integer)
-///     * `values-round-lower-bound` (boolean)
-///     * `values-round-upper-bound` (boolean)
+///     * `minimum-stride` (number)
+///     * `desired-count` (integer)
+///     * `round-lower-bound` (boolean)
+///     * `round-upper-bound` (boolean)
 /// * `stride`
 ///   * Additional Attributes
-///     * `values-stride` (number or ``LiveViewNativeCharts/Foundation/Calendar/Component``, required)
-///     * `values-count` (integer)
-///     * `values-round-lower-bound` (boolean)
-///     * `values-round-upper-bound` (boolean)
-///     * `values-calendar` (``LiveViewNativeCharts/Foundation/Calendar/Identifier``)
+///     * `stride` (number or ``LiveViewNativeCharts/Foundation/Calendar/Component``, required)
+///     * `count` (integer)
+///     * `round-lower-bound` (boolean)
+///     * `round-upper-bound` (boolean)
+///     * `calendar` (``LiveViewNativeCharts/Foundation/Calendar/Identifier``)
 extension AxisMarkValues {
     public init?(from element: ElementNode) {
         if let values = element.attributeValue(for: "values") {
             switch values {
             case "automatic":
-                if let minimumStride = try? element.attributeValue(Double.self, for: "values-minimum-stride") {
+                if let minimumStride = try? element.attributeValue(Double.self, for: "minimum-stride") {
                     self = .automatic(
                         minimumStride: minimumStride,
-                        desiredCount: try? element.attributeValue(Int.self, for: "values-desired-count"),
-                        roundLowerBound: element.attributeBoolean(for: "values-round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "values-round-upper-bound")
+                        desiredCount: try? element.attributeValue(Int.self, for: "desired-count"),
+                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
+                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
                     )
                 } else {
                     self = .automatic(
-                        desiredCount: try? element.attributeValue(Int.self, for: "values-desired-count"),
-                        roundLowerBound: element.attributeBoolean(for: "values-round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "values-round-upper-bound")
+                        desiredCount: try? element.attributeValue(Int.self, for: "desired-count"),
+                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
+                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
                     )
                 }
             case "stride":
-                if let numeric = try? element.attributeValue(Double.self, for: "values-stride") {
+                if let numeric = try? element.attributeValue(Double.self, for: "stride") {
                     self = .stride(
                         by: numeric,
-                        roundLowerBound: element.attributeBoolean(for: "values-round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "values-round-upper-bound")
+                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
+                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
                     )
-                } else if let component = try? element.attributeValue(Calendar.Component.self, for: "values-stride") {
+                } else if let component = try? element.attributeValue(Calendar.Component.self, for: "stride") {
                     self = .stride(
                         by: component,
-                        count: (try? element.attributeValue(Int.self, for: "values-count")) ?? 1,
-                        roundLowerBound: element.attributeBoolean(for: "values-round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "values-round-upper-bound"),
-                        calendar: (try? element.attributeValue(Calendar.Identifier.self, for: "values-calendar")).flatMap(Calendar.init(identifier:))
+                        count: (try? element.attributeValue(Int.self, for: "count")) ?? 1,
+                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
+                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound"),
+                        calendar: (try? element.attributeValue(Calendar.Identifier.self, for: "calendar")).flatMap(Calendar.init(identifier:))
                     )
                 }
             default:

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisMarkBuilder.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisMarkBuilder.swift
@@ -16,6 +16,9 @@ struct AxisMarkBuilder: ContentBuilder {
     
     enum TagName: String {
         case axisGridLine = "AxisGridLine"
+        case axisTick = "AxisTick"
+        case axisValue = "AxisValue"
+        case axisValueLabel = "AxisValueLabel"
     }
     
     enum ModifierType: String, Decodable {
@@ -32,6 +35,12 @@ struct AxisMarkBuilder: ContentBuilder {
         switch tag {
         case .axisGridLine:
             return AxisGridLine(element: element).body
+        case .axisTick:
+            return AxisTick(element: element).body
+        case .axisValue:
+            return AxisValue(element: element, context: context).body
+        case .axisValueLabel:
+            return AxisValueLabel(element: element, context: context).body
         }
     }
     

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
@@ -1,0 +1,66 @@
+//
+//  AxisTick.swift
+//
+//
+//  Created by Carson Katri on 6/14/23.
+//
+
+import Charts
+import LiveViewNative
+import LiveViewNativeCore
+
+/// An axis mark that adds ticks.
+///
+/// Use this element in the content of an ``AxisMarks`` element to display grid lines in your chart.
+///
+/// ```html
+/// <AxisMarks>
+///   <AxisTick
+///     centered
+///     length="longest-label"
+///     modifiers={foreground_style(@native, primary: {:color, :red})}
+///   />
+/// </AxisMarks>
+/// ```
+///
+/// ## Attributes
+/// * `centered` - Centers the ticks between two axis values.
+/// * `length` - The length of the ticks.
+/// * `stroke` - The ``LiveViewNativeCharts/SwiftUI/StrokeStyle`` to use.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct AxisTick: ComposedAxisMark {
+    let element: ElementNode
+    
+    var body: some AxisMark {
+        Charts.AxisTick(
+            centered: element.attributeBoolean(for: "centered"),
+            length: (try? element.attributeValue(for: "length")) ?? .automatic,
+            stroke: try? element.attributeValue(for: "stroke")
+        )
+    }
+}
+
+/// The length of a tick.
+///
+/// Possible values:
+/// * `automatic`
+/// * `label`
+/// * `longest-label`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension Charts.AxisTick.Length: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        switch value {
+        case "automatic": self = .automatic
+        case "label": self = .label
+        case "longest-label", "longest_label": self = .longestLabel
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
@@ -6,6 +6,7 @@
 //
 
 import Charts
+import SwiftUI
 import LiveViewNative
 import LiveViewNativeCore
 
@@ -36,8 +37,8 @@ struct AxisTick: ComposedAxisMark {
     var body: some AxisMark {
         Charts.AxisTick(
             centered: element.attributeBoolean(for: "centered"),
-            length: (try? element.attributeValue(for: "length")) ?? .automatic,
-            stroke: try? element.attributeValue(for: "stroke")
+            length: (try? element.attributeValue(Charts.AxisTick.Length.self, for: "length")) ?? .automatic,
+            stroke: try? element.attributeValue(StrokeStyle.self, for: "stroke")
         )
     }
 }

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValue.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValue.swift
@@ -6,7 +6,7 @@
 //
 
 import Charts
-@_spi(LiveViewNative) import LiveViewNative
+import LiveViewNative
 
 /// A value in an ``AxisMarks`` element.
 ///

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValue.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValue.swift
@@ -1,0 +1,41 @@
+//
+//  AxisValue.swift
+//
+//
+//  Created by Carson Katri on 6/15/23.
+//
+
+import Charts
+@_spi(LiveViewNative) import LiveViewNative
+
+/// A value in an ``AxisMarks`` element.
+///
+/// Use this element within an ``AxisMarks`` element to create custom marks.
+///
+/// - Note: Only numeric values are supported.
+///
+/// ```html
+/// <AxisMarks>
+///   <%= for item <- 1..10 do %>
+///     <AxisValue value={item}>
+///       <AxisValueLabel>Value: <%= item %></AxisValueLabel>
+///     </AxisValue>
+///   <% end %>
+/// </AxisMarks>
+/// ```
+///
+/// ## Attributes
+/// * `value`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct AxisValue<R: RootRegistry>: ComposedAxisMark {
+    let element: ElementNode
+    let context: AxisMarkBuilder.Context<R>
+    
+    var body: some AxisMark {
+        AnyAxisMark(
+            try! AxisMarkBuilder.buildChildren(of: element, in: context)
+        )
+    }
+}

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
@@ -7,7 +7,7 @@
 
 import Charts
 import SwiftUI
-@_spi(LiveViewNative) import LiveViewNative
+import LiveViewNative
 import LiveViewNativeCore
 
 /// An axis mark that adds labels.

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
@@ -22,6 +22,14 @@ import LiveViewNativeCore
 /// </AxisMarks>
 /// ```
 ///
+/// Custom views or text can also be displayed. This is especially useful when using ``AxisValue`` elements.
+///
+/// ```html
+/// <AxisValueLabel>
+///   <Image system-name="arrow.up" />
+/// </AxisValueLabel>
+/// ```
+///
 /// ## Attributes
 /// * `centered` - Centers the ticks between two axis values.
 /// * `length` - The length of the ticks.
@@ -31,7 +39,7 @@ import LiveViewNativeCore
 #endif
 struct AxisValueLabel<R: RootRegistry>: ComposedAxisMark {
     let element: ElementNode
-    let context: LiveContextStorage<R>
+    let context: AxisMarkBuilder.Context<R>
     
     var body: some AxisMark {
         let centered = element.attributeBoolean(for: "centered")
@@ -110,8 +118,8 @@ struct AxisValueLabel<R: RootRegistry>: ComposedAxisMark {
             case "byte-count", "byte_count":
                 Charts.AxisValueLabel(
                     format: .byteCount(
-                        style: (try? element.attributeValue(for: "style")) ?? .binary,
-                        allowedUnits: (try? element.attributeValue(for: "allowed-units")) ?? .default,
+                        style: (try? element.attributeValue(ByteCountFormatStyle.Style.self, for: "style")) ?? .binary,
+                        allowedUnits: (try? element.attributeValue(ByteCountFormatStyle.Units.self, for: "allowed-units")) ?? .default,
                         spellsOutZero: element.attributeBoolean(for: "spells-out-zero"),
                         includesActualByteCount: element.attributeBoolean(for: "includes-actual-byte-count")
                     ),
@@ -138,7 +146,10 @@ struct AxisValueLabel<R: RootRegistry>: ComposedAxisMark {
                 horizontalSpacing: horizontalSpacing,
                 verticalSpacing: verticalSpacing
             ) {
-                ViewTreeBuilder<R>().fromNodes(element.children(), context: context)
+                AxisMarkBuilder.buildChildrenViews(
+                    of: element,
+                    in: context
+                )
             }
         }
     }

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
@@ -146,7 +146,7 @@ struct AxisValueLabel<R: RootRegistry>: ComposedAxisMark {
                 horizontalSpacing: horizontalSpacing,
                 verticalSpacing: verticalSpacing
             ) {
-                AxisMarkBuilder.buildChildrenViews(
+                AxisMarkBuilder.buildChildViews(
                     of: element,
                     in: context
                 )

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisValueLabel.swift
@@ -1,0 +1,175 @@
+//
+//  AxisValueLabel.swift
+//
+//
+//  Created by Carson Katri on 6/15/23.
+//
+
+import Charts
+import SwiftUI
+@_spi(LiveViewNative) import LiveViewNative
+import LiveViewNativeCore
+
+/// An axis mark that adds labels.
+///
+/// Use this element in the content of an ``AxisMarks`` element to display labels in your chart.
+///
+/// ```html
+/// <AxisMarks>
+///   <AxisValueLabel
+///     format="date-time"
+///   />
+/// </AxisMarks>
+/// ```
+///
+/// ## Attributes
+/// * `centered` - Centers the ticks between two axis values.
+/// * `length` - The length of the ticks.
+/// * `stroke` - The ``LiveViewNativeCharts/SwiftUI/StrokeStyle`` to use.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct AxisValueLabel<R: RootRegistry>: ComposedAxisMark {
+    let element: ElementNode
+    let context: LiveContextStorage<R>
+    
+    var body: some AxisMark {
+        let centered = element.attributeBoolean(for: "centered")
+        let anchor = try? element.attributeValue(UnitPoint.self, for: "anchor")
+        let multiLabelAlignment = try? element.attributeValue(Alignment.self, for: "multi-label-alignment")
+        let collisionResolution = (try? element.attributeValue(AxisValueLabelCollisionResolution.self, for: "collision-resolution")) ?? .automatic
+        let offsetsMarks = element.attributeBoolean(for: "offsets-marks")
+        let orientation = (try? element.attributeValue(AxisValueLabelOrientation.self, for: "orientation")) ?? .automatic
+        let horizontalSpacing = (try? element.attributeValue(Double.self, for: "horizontal-spacing"))
+            .flatMap(CGFloat.init)
+        let verticalSpacing = (try? element.attributeValue(Double.self, for: "vertical-spacing"))
+            .flatMap(CGFloat.init)
+        
+        if let format = element.attributeValue(for: "format") {
+            switch format {
+            case "date-time", "date_time":
+                Charts.AxisValueLabel(
+                    format: .dateTime,
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            case "iso8601":
+                Charts.AxisValueLabel(
+                    format: .iso8601,
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            case "number":
+                Charts.AxisValueLabel(
+                    format: FloatingPointFormatStyle<Double>.number,
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            case "percent":
+                Charts.AxisValueLabel(
+                    format: FloatingPointFormatStyle<Double>.Percent.percent,
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            case "currency":
+                Charts.AxisValueLabel(
+                    format: .currency(code: element.attributeValue(for: "currency-code") ?? "usd"),
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            case "byte-count", "byte_count":
+                Charts.AxisValueLabel(
+                    format: .byteCount(
+                        style: (try? element.attributeValue(for: "style")) ?? .binary,
+                        allowedUnits: (try? element.attributeValue(for: "allowed-units")) ?? .default,
+                        spellsOutZero: element.attributeBoolean(for: "spells-out-zero"),
+                        includesActualByteCount: element.attributeBoolean(for: "includes-actual-byte-count")
+                    ),
+                    centered: centered,
+                    anchor: anchor,
+                    multiLabelAlignment: multiLabelAlignment,
+                    collisionResolution: collisionResolution,
+                    offsetsMarks: offsetsMarks,
+                    orientation: orientation,
+                    horizontalSpacing: horizontalSpacing,
+                    verticalSpacing: verticalSpacing
+                )
+            default:
+                fatalError("Unknown format '\(format)'")
+            }
+        } else {
+            Charts.AxisValueLabel(
+                centered: centered,
+                anchor: anchor,
+                multiLabelAlignment: multiLabelAlignment,
+                collisionResolution: collisionResolution,
+                offsetsMarks: offsetsMarks,
+                orientation: orientation,
+                horizontalSpacing: horizontalSpacing,
+                verticalSpacing: verticalSpacing
+            ) {
+                ViewTreeBuilder<R>().fromNodes(element.children(), context: context)
+            }
+        }
+    }
+}
+
+extension AxisValueLabelCollisionResolution: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        switch value {
+        case "automatic": self = .automatic
+        case "greedy": self = .greedy
+        case "truncate": self = .truncate
+        case "disabled": self = .disabled
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}
+
+extension AxisValueLabelOrientation: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        switch value {
+        case "automatic": self = .automatic
+        case "horizontal": self = .horizontal
+        case "vertical": self = .vertical
+        case "vertical-reversed", "vertical_reversed": self = .verticalReversed
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}


### PR DESCRIPTION
Closes #10 
Closes #12 

This also adds a new `AxisValue` element that can be used with `AxisMarks` to create custom axis marks.

Here is the Swift code and equivalent markup:

```swift
AxisMarks(values: [1, 2, 3, 4, 5]) { value in
  AxisValueLabel {
    Image(systemName: "\(value.as(Int.self)).circle.fill")
  }
  AxisTick()
}
```
```heex
<AxisMarks>
  <%= for value <- [1, 2, 3, 4, 5] do %>
    <AxisValue value={value}>
      <AxisValueLabel>
        <Image system-name={"#{value}.circle.fill"} />
      </AxisValueLabel>
      <AxisTick />
    </AxisValue>
  <% end %>
</AxisMarks>
```