### PR TITLE
Add ChartContent modifiers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liveview-native/liveview-client-swiftui",
       "state" : {
-        "branch" : "content-builder",
-        "revision" : "b80ea68b9d2ccf9e0d695b1f89e41278f003e740"
+        "branch" : "public-shape-reference",
+        "revision" : "f34539a94ac3b323b1b1995e5907cb1bc8d4e193"
       }
     },
     {
@@ -25,6 +25,15 @@
       "state" : {
         "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
         "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "f1e9245226002bb134884345d4809b9543da3666",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-17-a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["LiveViewNativeCharts"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/liveview-native/liveview-client-swiftui", branch: "content-builder")
+        .package(url: "https://github.com/liveview-native/liveview-client-swiftui", branch: "public-shape-reference")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
+++ b/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
@@ -371,7 +371,8 @@ extension Calendar.Component: AttributeDecodable {
         case "nanosecond": self = .nanosecond
         case "calendar": self = .calendar
         case "time_zone": self = .timeZone
-        case "is_leap_month": self = .isLeapMonth
+//      this crashes with Xcode 15 beta, but according to the docs should exist.
+//        case "is_leap_month": self = .isLeapMonth
         default: throw AttributeDecodingError.badValue(Self.self)
         }
     }

--- a/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
+++ b/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
@@ -31,6 +31,7 @@ struct ChartContentBuilder: ContentBuilder {
         case mask
         case offset
         case opacity
+        case shadow
         case symbol
     }
     
@@ -87,6 +88,12 @@ struct ChartContentBuilder: ContentBuilder {
             return try OffsetModifier(from: decoder)
         case .opacity:
             return try OpacityModifier(from: decoder)
+        case .shadow:
+            if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
+                return try ShadowModifier(from: decoder)
+            } else {
+                return EmptyContentModifier<Self>()
+            }
         case .symbol:
             return try SymbolModifier(from: decoder)
         }

--- a/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
+++ b/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
@@ -25,6 +25,7 @@ struct ChartContentBuilder: ContentBuilder {
     }
     
     enum ModifierType: String, Decodable {
+        case blur
         case clipShape = "clip_shape"
         case foregroundStyle = "foreground_style"
         case mask
@@ -70,6 +71,12 @@ struct ChartContentBuilder: ContentBuilder {
         registry _: R.Type
     ) throws -> any ContentModifier<Self> {
         switch type {
+        case .blur:
+            if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
+                return try BlurModifier(from: decoder)
+            } else {
+                return EmptyContentModifier<Self>()
+            }
         case .clipShape:
             return try ClipShapeModifier(from: decoder)
         case .foregroundStyle:

--- a/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
+++ b/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
@@ -26,6 +26,7 @@ struct ChartContentBuilder: ContentBuilder {
     
     enum ModifierType: String, Decodable {
         case foregroundStyle = "foreground_style"
+        case mask
         case offset
         case opacity
         case symbol
@@ -70,6 +71,8 @@ struct ChartContentBuilder: ContentBuilder {
         switch type {
         case .foregroundStyle:
             return try ForegroundStyleModifier(from: decoder)
+        case .mask:
+            return try MaskModifier(from: decoder)
         case .offset:
             return try OffsetModifier(from: decoder)
         case .opacity:

--- a/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
+++ b/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
@@ -25,6 +25,7 @@ struct ChartContentBuilder: ContentBuilder {
     }
     
     enum ModifierType: String, Decodable {
+        case clipShape = "clip_shape"
         case foregroundStyle = "foreground_style"
         case mask
         case offset
@@ -69,6 +70,8 @@ struct ChartContentBuilder: ContentBuilder {
         registry _: R.Type
     ) throws -> any ContentModifier<Self> {
         switch type {
+        case .clipShape:
+            return try ClipShapeModifier(from: decoder)
         case .foregroundStyle:
             return try ForegroundStyleModifier(from: decoder)
         case .mask:

--- a/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
+++ b/Sources/LiveViewNativeCharts/ChartContentBuilder.swift
@@ -27,6 +27,7 @@ struct ChartContentBuilder: ContentBuilder {
     enum ModifierType: String, Decodable {
         case foregroundStyle = "foreground_style"
         case offset
+        case opacity
         case symbol
     }
     
@@ -71,6 +72,8 @@ struct ChartContentBuilder: ContentBuilder {
             return try ForegroundStyleModifier(from: decoder)
         case .offset:
             return try OffsetModifier(from: decoder)
+        case .opacity:
+            return try OpacityModifier(from: decoder)
         case .symbol:
             return try SymbolModifier(from: decoder)
         }

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/BlurModifier.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/BlurModifier.md
@@ -1,0 +1,6 @@
+# ``LiveViewNativeCharts/BlurModifier``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+    @DisplayName("blur", style: symbol)
+}

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/ClipShapeModifier.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/ClipShapeModifier.md
@@ -1,0 +1,6 @@
+# ``LiveViewNativeCharts/ClipShapeModifier``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+    @DisplayName("clip_shape", style: symbol)
+}

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/MaskModifier.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/MaskModifier.md
@@ -1,0 +1,6 @@
+# ``LiveViewNativeCharts/MaskModifier``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+    @DisplayName("mask", style: symbol)
+}

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/OpacityModifier.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/OpacityModifier.md
@@ -1,0 +1,6 @@
+# ``LiveViewNativeCharts/OpacityModifier``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+    @DisplayName("opacity", style: symbol)
+}

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/ShadowModifier.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Extensions/ShadowModifier.md
@@ -1,0 +1,6 @@
+# ``LiveViewNativeCharts/ShadowModifier``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: append)
+    @DisplayName("shadow", style: symbol)
+}

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Add this library as a package to your LiveView Native application's Xcode project using its repo URL. Then, create an `AggregateRegistry` to include the provided `ChartsRegistry` within your native app builds:
+Add this library as a package to your LiveView Native application's Xcode project using its repo URL. Then, create an ``LiveViewNativeCharts/LiveViewNative/AggregateRegistry`` to include the provided ``ChartsRegistry`` within your native app builds:
 
 ```diff
 import SwiftUI

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Marks.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Marks.md
@@ -39,5 +39,11 @@ Each mark supports different values. These attributes are detailed in their docu
 - ``Plot``
 
 ### Modifiers
+- ``BlurModifier``
+- ``ClipShapeModifier``
 - ``ForegroundStyleModifier``
+- ``MaskModifier``
 - ``OffsetModifier``
+- ``OpacityModifier``
+- ``ShadowModifier``
+- ``SymbolModifier``

--- a/Sources/LiveViewNativeCharts/Modifiers/BlurModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/BlurModifier.swift
@@ -1,0 +1,42 @@
+//
+//  BlurModifier.swift
+//
+//
+//  Created by Carson Katri on 6/27/23.
+//
+
+import Charts
+import SwiftUI
+import LiveViewNative
+
+/// Applies a Gaussian blur to the element.
+///
+/// Set the ``radius`` to control the strength of the blur.
+///
+/// ```html
+/// <BarMark modifiers={blur(radius: 2)} ... />
+/// ```
+///
+/// ## Arguments
+/// * ``radius``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+@available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+struct BlurModifier: ContentModifier {
+    typealias Builder = ChartContentBuilder
+    
+    /// The strength of the blur.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let radius: CGFloat
+    
+    func apply<R>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content where R : RootRegistry {
+        return content.blur(radius: radius)
+    }
+}

--- a/Sources/LiveViewNativeCharts/Modifiers/ClipShapeModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ClipShapeModifier.swift
@@ -1,0 +1,77 @@
+//
+//  ClipShapeModifier.swift
+//  
+//
+//  Created by Carson Katri on 6/27/23.
+//
+
+import Charts
+import SwiftUI
+import LiveViewNative
+
+// this modifier is created by `liveview-client-swiftui`, and an implementation for Charts is provided here.
+/// Masks an element with a given shape.
+///
+/// Provide a ``LiveViewNativeCharts/LiveViewNative/ShapeReference`` to clip the element with.
+///
+/// ```html
+/// <BarMark modifiers={clip_shape(shape: :capsule)} ... />
+/// ```
+///
+/// If the shape is not predefined, provide a ``LiveViewNativeCharts/LiveViewNative/Shape`` element with a `template` attribute.
+/// This lets you apply modifiers to the clip shape.
+///
+/// ```html
+/// <BarMark modifiers={clip_shape(shape: :my_shape)} ...>
+///     <Rectangle template={:my_shape} modifiers={rotation(angle: {:degrees, 45})} />
+/// </BarMark>
+/// ```
+///
+/// ## Arguments
+/// * ``shape``
+/// * ``style``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ClipShapeModifier: ContentModifier {
+    typealias Builder = ChartContentBuilder
+    
+    /// The shape to use as a mask.
+    ///
+    /// See ``ShapeReference`` for more details on creating shape arguments.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let shape: ShapeReference
+
+    /// The style to use when filling the ``shape`` for the mask.
+    ///
+    /// See ``LiveViewNative/SwiftUI/FillStyle`` for more details.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let style: FillStyle
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.shape = try container.decode(ShapeReference.self, forKey: .shape)
+        self.style = try container.decodeIfPresent(FillStyle.self, forKey: .style) ?? .init()
+    }
+
+    func apply<R>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content where R : RootRegistry {
+        content.clipShape(
+            shape.resolve(on: element),
+            style: style
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case shape
+        case style
+    }
+}

--- a/Sources/LiveViewNativeCharts/Modifiers/MaskModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/MaskModifier.swift
@@ -1,0 +1,52 @@
+//
+//  MaskModifier.swift
+//
+//
+//  Created by Carson Katri on 6/27/23.
+//
+
+import Charts
+import LiveViewNative
+
+// this modifier is created by `liveview-client-swiftui`, and an implementation for Charts is provided here.
+/// Masks this chart content using the alpha channel of the given chart content.
+///
+/// ```html
+/// <RectangleMark
+///   modifiers={mask(content: :my_mask)}
+///   x-start={0} x-start:label=" "
+///   x-end={10} x-end:label=" "
+/// >
+///   <AreaMark
+///     template={:my_mask}
+///     :for={item <- 0..10}
+///     x={item} x:label="Time"
+///     y={item} y:label="Value"
+///   />
+/// </RectangleMark>
+/// ```
+///
+/// ## Arguments
+/// * ``content``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct MaskModifier: ContentModifier {
+    typealias Builder = ChartContentBuilder
+    
+    /// The content to use as the mask.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let content: String
+    
+    func apply<R: RootRegistry>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content {
+        content.mask {
+            AnyChartContent(try! Builder.buildChildren(of: element, forTemplate: self.content, in: context))
+        }
+    }
+}

--- a/Sources/LiveViewNativeCharts/Modifiers/OffsetModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/OffsetModifier.swift
@@ -44,12 +44,44 @@ struct OffsetModifier: ContentModifier {
     #endif
     let y: Double?
     
+    /// The vertical offset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let xStart: Double?
+    
+    /// The vertical offset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let xEnd: Double?
+    
+    /// The vertical offset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let yStart: Double?
+    
+    /// The vertical offset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let yEnd: Double?
+    
     func apply<R: RootRegistry>(
         to content: Builder.Content,
         on element: ElementNode,
         in context: Builder.Context<R>
     ) -> Builder.Content {
-        content.offset(x: x ?? 0, y: y ?? 0)
+        if (xStart != nil || xEnd != nil) && (yStart != nil || yEnd != nil) {
+            return content.offset(xStart: xStart ?? 0, xEnd: xEnd ?? 0, yStart: yStart ?? 0, yEnd: yEnd ?? 0)
+        } else if yStart != nil || yEnd != nil {
+            return content.offset(x: x ?? 0, yStart: yStart ?? 0, yEnd: yEnd ?? 0)
+        } else if xStart != nil || xEnd != nil {
+            return content.offset(xStart: xStart ?? 0, xEnd: xEnd ?? 0, y: y ?? 0)
+        } else {
+            return content.offset(x: x ?? 0, y: y ?? 0)
+        }
     }
 }
 

--- a/Sources/LiveViewNativeCharts/Modifiers/OpacityModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/OpacityModifier.swift
@@ -1,0 +1,41 @@
+//
+//  OpacityModifier.swift
+//  
+//
+//  Created by Carson Katri on 6/23/23.
+//
+
+import Charts
+import LiveViewNative
+
+// this modifier is created by `liveview-client-swiftui`, and an implementation for Charts is provided here.
+/// Set the opacity for chart content.
+///
+/// Use this modifier on a mark to set its opacity.
+///
+/// ```html
+/// <BarMark modifiers={opacity(0.5)} />
+/// ```
+///
+/// ## Arguments
+/// * ``opacity``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct OpacityModifier: ContentModifier {
+    typealias Builder = ChartContentBuilder
+    
+    /// The opacity to apply.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    let opacity: Double
+    
+    func apply<R: RootRegistry>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content {
+        content.opacity(opacity)
+    }
+}

--- a/Sources/LiveViewNativeCharts/Modifiers/ShadowModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ShadowModifier.swift
@@ -1,0 +1,69 @@
+//
+//  File.swift
+//  
+//
+//  Created by Carson.Katri on 6/27/23.
+//
+
+import Charts
+import SwiftUI
+import LiveViewNative
+
+// this modifier is created by `liveview-client-swiftui`, and an implementation for Charts is provided here.
+/// Adds a shadow behind the chart content.
+///
+/// Use this modifier to style a mark.
+///
+/// ```html
+/// <BarMark modifiers={shadow(color: :black, radius: 10)} ... />
+/// ```
+///
+/// ## Arguments
+/// * ``color``
+/// * ``radius``
+/// * ``x``
+/// * ``y``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+@available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+struct ShadowModifier: ContentModifier {
+    typealias Builder = ChartContentBuilder
+    
+    /// The shadow’s color.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let color: SwiftUI.Color
+
+    /// A measure of how much to blur the shadow. Larger values result in more blur.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let radius: CGFloat
+
+    /// An amount to offset the shadow horizontally from the view. Defaults to 0.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let x: CGFloat
+
+    /// An amount to offset the shadow vertically from the view. Defaults to 0.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let y: CGFloat
+    
+    func apply<R: RootRegistry>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content {
+        content.shadow(
+            color: color,
+            radius: radius,
+            x: x,
+            y: y
+        )
+    }
+}

--- a/lib/live_view_native_swift_ui_charts/modifiers/offset.ex
+++ b/lib/live_view_native_swift_ui_charts/modifiers/offset.ex
@@ -1,0 +1,14 @@
+defmodule LiveViewNativeSwiftUiCharts.Modifiers.Offset do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "offset" do
+    field :x, :float, default: nil
+    field :y, :float, default: nil
+
+    field :x_start, :float, default: nil
+    field :x_end, :float, default: nil
+
+    field :y_start, :float, default: nil
+    field :y_end, :float, default: nil
+  end
+end


### PR DESCRIPTION
This adds support for modifiers that have their schema defined in `liveview-client-swiftui`.

Depends on https://github.com/liveview-native/liveview-client-swiftui/pull/995

Closes #51 
Closes #58 
Closes #71 
Closes #72 
Closes #78 
Closes #81 