### PR TITLE
Fix Swift 5.8 compile errors

### DIFF
--- a/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
+++ b/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
@@ -371,7 +371,8 @@ extension Calendar.Component: AttributeDecodable {
         case "nanosecond": self = .nanosecond
         case "calendar": self = .calendar
         case "time_zone": self = .timeZone
-        case "is_leap_month": self = .isLeapMonth
+	// Remove for now since throws error under Xcode 15/Swift 5.8
+        //case "is_leap_month": self = .isLeapMonth
         default: throw AttributeDecodingError.badValue(Self.self)
         }
     }

--- a/Sources/LiveViewNativeCharts/Modifiers/ZIndexModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ZIndexModifier.swift
@@ -37,6 +37,10 @@ struct ZIndexModifier: ContentModifier {
         on element: ElementNode,
         in context: Builder.Context<R>
     ) -> Builder.Content {
-        content.zIndex(value)
-    }
+        #if swift(>=5.9)
+            content.zIndex(value)
+        #else
+            content
+        #endif
+}
 }


### PR DESCRIPTION
Adds a conditional around `content.zIndex` which was introduced in Swift 5.9 and takes out case option for `isLeapMonth` since Swift 5.8 is unhappy with it.