### PR TITLE
Update `PlottableValue` attributes and README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["LiveViewNativeCharts"]),
     ],
     dependencies: [
-       .package(url: "https://github.com/liveview-native/liveview-client-swiftui", from: "0.2.0")
+       .package(url: "https://github.com/liveview-native/liveview-client-swiftui", branch: "main")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -1,87 +1,77 @@
-# liveview-native-swiftui-charts
-
-## About
+# Charts for LiveView Native SwiftUI
 
 `liveview-native-swiftui-charts` is an add-on library for [LiveView Native](https://github.com/liveview-native/live_view_native). It adds [Swift Charts](https://developer.apple.com/documentation/charts) support for data visualization.
 
+## Installation
+
+1. In Xcode, select *File → Add Packages...*
+2. Enter the package URL `https://github.com/liveview-native/liveview-native-swiftui-charts`
+3. Select *Add Package*
+
 ## Usage
 
-Add this library as a package to your LiveView Native application's Xcode project using its repo URL. Then, create an `AggregateRegistry` to include the provided `ChartsRegistry` within your native app builds:
+Import `LiveViewNativeCharts` and add the `ChartsRegistry` to the list of addons on your `LiveView`:
 
-```diff
+```swift
 import SwiftUI
 import LiveViewNative
-+ import LiveViewNativeCharts
-+ 
-+ struct MyRegistry: CustomRegistry {
-+     typealias Root = AppRegistries
-+ }
-+ 
-+ struct AppRegistries: AggregateRegistry {
-+     #Registries<
-+         MyRegistry,
-+         ChartsRegistry<Self>
-+     >
-+ }
+import LiveViewNativeCharts
 
-@MainActor
 struct ContentView: View {
--     @StateObject private var session: LiveSessionCoordinator<EmptyRegistry> = {
-+     @StateObject private var session: LiveSessionCoordinator<AppRegistries> = {
-        var config = LiveSessionConfiguration()
-        config.navigationMode = .enabled
-        
-        return LiveSessionCoordinator(URL(string: "http://localhost:4000/")!, config: config)
-    }()
-
     var body: some View {
-        LiveView(session: session)
+        #LiveView(
+            .localhost,
+            addons: [ChartsRegistry<_>.self]
+        )
     }
 }
 ```
 
-To render a chart within a SwiftUI HEEx template, use the `Chart` element.
-Include mark elements within the chart to display some data:
+Now you can use the `Chart` element in your template.
 
-```elixir
-defmodule MyAppWeb.ChartLive do
-  use Phoenix.LiveView
-  use LiveViewNative.LiveView
+<table>
 
-  def mount(_params, _session, socket) do
-    {:ok, assign(socket, data: [
-      %{ department: "Production", profit: 4000, product_category: "Gizmos" },
-      %{ department: "Marketing", profit: 2000, product_category: "Gizmos" },
-      %{ department: "Finance", profit: 2000, product_category: "Gizmos" },
-      ...
-    ])}
-  end
+<tr>
+<td>
 
-  @impl true
-  def render(%{platform_id: :swiftui} = assigns) do
-    ~Z"""
-    <Chart>
-      <%= for item <- @data do %>
-        <BarMark
-          x={item.department}
-          x:label="Department"
+```heex
+<Chart>
+  <BarMark
+    :for={item <- @data}
 
-          y={item.profit}
-          y:label="Profit"
+    x:label="Department"
+    x:value={item.department}
 
-          modifiers={@native |> foreground_style(value: {"Product Category", item.product_category})}
-        />
-      <% end %>
-    </Chart>
-    """swiftui
-  end
+    y:label="Profit"
+    y:value={item.profit}
+
+    class="fg-product-category"
+    product-category={item.product_category}
+  />
+</Chart>
+```
+```ex
+~SHEET"""
+"fg-product-category" do
+  foregroundStyle(by: .value("Product Category", attr("product-category")))
 end
+"""
 ```
 
-![LiveView Native Charts screenshot](./docs/example.png)
+</td>
+
+<td>
+<img src="./docs/example.png" alt="LiveView Native Charts screenshot" width="300" />
+</td>
+
+</tr>
+
+</table>
 
 ## Learn more
 
-  * Official website: https://native.live
-  * Docs: https://hexdocs.pm/live_view_native_platform
-  * Source: https://github.com/liveviewnative/live_view_native_platform
+You can view documentation on the elements and attributes in this addon from Xcode:
+
+1. In Xcode, select *Product → Build Documentation* in the menu bar
+2. Select *Window → Developer Documentation* (Xcode should open this for you after the documentation is built)
+3. Select *LiveViewNativeCharts* in the sidebar

--- a/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
+++ b/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
@@ -40,7 +40,7 @@ import SwiftUI
 ///
 /// ```html
 /// <AxisMarks>
-///   <AxisGridLine modifiers={foreground_style(@native, primary: {:color, :red})} />
+///   <AxisGridLine class="fg-red" />
 /// </AxisMarks>
 /// ```
 ///

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisGridLine.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisGridLine.swift
@@ -17,7 +17,7 @@ import LiveViewNative
 /// <AxisMarks>
 ///   <AxisGridLine
 ///     centered
-///     modifiers={foreground_style(@native, primary: {:color, :red})}
+///     class="fg-red"
 ///   />
 /// </AxisMarks>
 /// ```

--- a/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
+++ b/Sources/LiveViewNativeCharts/AxisMark/AxisTick.swift
@@ -19,7 +19,7 @@ import LiveViewNativeCore
 ///   <AxisTick
 ///     centered
 ///     length="longest-label"
-///     modifiers={foreground_style(@native, primary: {:color, :red})}
+///     class="fg-red"
 ///   />
 /// </AxisMarks>
 /// ```

--- a/Sources/LiveViewNativeCharts/ChartContent/AnyMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/AnyMark.swift
@@ -128,23 +128,23 @@ struct AnyMark<M: MarkProtocol>: ChartContent {
             .flatMap(Double.init(_:))
             .flatMap(CGFloat.init(_:))
         
-        let xStart = element.plottable(named: "x-start")
-        let xEnd = element.plottable(named: "x-end")
+        let xStart = element.plottable(named: "xStart")
+        let xEnd = element.plottable(named: "xEnd")
         
-        let fixedXStart = element.attributeValue(for: "x-start")
+        let fixedXStart = element.attributeValue(for: "xStart")
             .flatMap(Double.init(_:))
             .flatMap(CGFloat.init(_:))
-        let fixedXEnd = element.attributeValue(for: "x-end")
+        let fixedXEnd = element.attributeValue(for: "xEnd")
             .flatMap(Double.init(_:))
             .flatMap(CGFloat.init(_:))
         
-        let yStart = element.plottable(named: "y-start")
-        let yEnd = element.plottable(named: "y-end")
+        let yStart = element.plottable(named: "yStart")
+        let yEnd = element.plottable(named: "yEnd")
         
-        let fixedYStart = element.attributeValue(for: "y-start")
+        let fixedYStart = element.attributeValue(for: "yStart")
             .flatMap(Double.init(_:))
             .flatMap(CGFloat.init(_:))
-        let fixedYEnd = element.attributeValue(for: "y-end")
+        let fixedYEnd = element.attributeValue(for: "yEnd")
             .flatMap(Double.init(_:))
             .flatMap(CGFloat.init(_:))
         

--- a/Sources/LiveViewNativeCharts/ChartContent/AreaMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/AreaMark.swift
@@ -14,11 +14,11 @@ import LiveViewNative
 ///
 /// ```html
 /// <AreaMark
-///   x={item.date}
 ///   x:label="Date"
+///   x:value={item.date}
 ///
-///   y={item.profit}
 ///   y:label="Profit"
+///   y:value={item.profit}
 /// />
 /// ```
 ///
@@ -27,23 +27,23 @@ import LiveViewNative
 ///
 /// ```html
 /// <AreaMark
-///   x={item.time}
 ///   x:label="Time"
+///   x:value={item.time}
 ///
-///   y-start={item.low}
-///   y-start:label="Low Temperature"
-///   y-end={item.high}
-///   y-end:label="High Temperature"
+///   yStart:label="Low Temperature"
+///   yStart:value={item.low}
+///   yEnd:label="High Temperature"
+///   yEnd:value={item.high}
 /// />
 /// ```
 ///
 /// ## Attributes
 /// * `x`
 /// * `y`
-/// * `x-start`
-/// * `x-end`
-/// * `y-start`
-/// * `y-end`
+/// * `xStart`
+/// * `xEnd`
+/// * `yStart`
+/// * `yEnd`
 /// * `series`
 /// * `stacking` - The ``LiveViewNativeCharts/Charts/MarkStackingMethod``
 #if swift(>=5.8)

--- a/Sources/LiveViewNativeCharts/ChartContent/BarMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/BarMark.swift
@@ -15,11 +15,11 @@ import LiveViewNative
 ///
 /// ```html
 /// <BarMark
-///   x={item.date}
 ///   x:label="Date"
+///   x:value={item.date}
 ///
-///   y={item.profit}
 ///   y:label="Profit"
+///   y:value={item.profit}
 /// />
 /// ```
 ///
@@ -29,37 +29,45 @@ import LiveViewNative
 ///
 /// ```html
 /// <BarMark
-///   x={item.profit}
 ///   x:label="Profit"
+///   x:value={item.profit}
 ///
-///   modifiers={@native |> foreground_style(value: {"Product", item.product})}
+///   class="fg-product"
+///   product={item.product}
 /// />
+/// ```
+///
+/// ```elixir
+/// ~SHEET"""
+/// "fg-product" do
+///   foregroundStyle(by: .value("Product", attr("product")))
+/// end
 /// ```
 ///
 /// - Note: The example above uses the ``ForegroundStyleModifier`` modifier to represent categories with colors.
 ///
-/// Use the `x-start`/`x-end` or `y-start`/`y-end` attributes to create an interval bar.
+/// Use the `xStart`/`xEnd` or `yStart`/`yEnd` attributes to create an interval bar.
 ///
 /// ```html
 /// <BarMark
-///   x-start={item.start}
-///   x-start:label="Start Time"
+///   xStart:label="Start Time"
+///   xStart:value={item.start}
 ///
-///   x-end={item.end}
-///   x-end:label="End Time"
+///   xEnd:label="End Time"
+///   xEnd:value={item.end}
 ///
-///   y={item.job}
 ///   y:label="Job"
+///   y:value={item.job}
 /// />
 /// ```
 ///
 /// ## Attributes
 /// * `x`
 /// * `y`
-/// * `x-start`
-/// * `x-end`
-/// * `y-start`
-/// * `y-end`
+/// * `xStart`
+/// * `xEnd`
+/// * `yStart`
+/// * `yEnd`
 /// * `width` - The bar width as a ``LiveViewNativeCharts/Charts/MarkDimension``
 /// * `height` - The bar height as a ``LiveViewNativeCharts/Charts/MarkDimension``
 /// * `stacking` - The ``LiveViewNativeCharts/Charts/MarkStackingMethod``

--- a/Sources/LiveViewNativeCharts/ChartContent/LineMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/LineMark.swift
@@ -12,11 +12,11 @@ import LiveViewNative
 ///
 /// ```html
 /// <LineMark
-///   x={item.date}
 ///   x:label="Date"
+///   x:value={item.date}
 ///
-///   y={item.profit}
 ///   y:label="Profit"
+///   y:value={item.profit}
 /// />
 /// ```
 ///
@@ -24,14 +24,14 @@ import LiveViewNative
 ///
 /// ```html
 /// <LineMark
-///   x={item.date}
 ///   x:label="Date"
+///   x:value={item.date}
 ///
-///   y={item.profit}
 ///   y:label="Profit"
+///   y:value={item.profit}
 ///
-///   series={item.product}
 ///   series:label="Product"
+///   series:value={item.product}
 /// />
 /// ```
 ///

--- a/Sources/LiveViewNativeCharts/ChartContent/PointMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/PointMark.swift
@@ -13,11 +13,11 @@ import LiveViewNative
 ///
 /// ```html
 /// <PointMark
-///   x={item.date}
 ///   x:label="Date"
+///   x:value={item.date}
 ///
-///   y={item.profit}
 ///   y:label="Profit"
+///   y:value={item.profit}
 /// />
 /// ```
 ///

--- a/Sources/LiveViewNativeCharts/ChartContent/RectangleMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/RectangleMark.swift
@@ -15,47 +15,56 @@ import LiveViewNative
 ///
 /// ```html
 /// <RectangleMark
-///   x={item.positive}
 ///   x:label="Positive"
+///   x:value={item.positive}
 ///
-///   y={item.negative}
 ///   y:label="Negative"
+///   y:value={item.negative}
 ///
-///   modifiers={@native |> foreground_style(value: {"Number", item.num})}
+///   class="fg-number"
+///   number={item.num}
 /// />
 /// ```
 ///
-/// Provide an `x-start`/`x-end` and `y-start`/`y-end` to manually specify the area to fill.
+/// ```elixir
+/// ~SHEET"""
+/// "fg-number" do
+///   foregroundStyle(by: .value("Number", attr("number")))
+/// end
+/// """
+/// ```
+///
+/// Provide an `xStart`/`xEnd` and `yStart`/`yEnd` to manually specify the area to fill.
 ///
 /// ```html
 /// <RectangleMark
-///   x-start={item.x - 0.25}
-///   x-start:label="Rect Start Width"
-///   x-end={item.x + 0.25}
-///   x-end:label="Rect End Width"
-///   y-start={item.y - 0.25}
-///   y-start:label="Rect Start Height"
-///   y-end={item.y + 0.2}
-///   y-end:label="Rect End Height"
+///   xStart:label="Rect Start Width"
+///   xStart:value={item.x - 0.25}
+///   xEnd:label="Rect End Width"
+///   xEnd:value={item.x + 0.25}
+///   yStart:label="Rect Start Height"
+///   yStart:value={item.y - 0.25}
+///   yEnd:label="Rect End Height"
+///   yEnd:value={item.y + 0.2}
 ///
-///   modifiers={@native |> foreground_style(primary: {:color, :blue, [{:opacity, 0.5}]})}
+///   class="fg-blue"
 /// />
 ///
 /// <PointMark
-///   x={item.x}
 ///   x:label="X"
-///   y={item.y}
+///   x:value={item.x}
 ///   y:label="Y"
+///   y:value={item.y}
 /// />
 /// ```
 ///
 /// ## Attributes
 /// * `x`
 /// * `y`
-/// * `x-start`
-/// * `x-end`
-/// * `y-start`
-/// * `y-end`
+/// * `xStart`
+/// * `xEnd`
+/// * `yStart`
+/// * `yEnd`
 /// * `width` - The rectangle width as a ``LiveViewNativeCharts/Charts/MarkDimension``
 /// * `height` - The rectangle height as a ``LiveViewNativeCharts/Charts/MarkDimension``
 #if swift(>=5.8)

--- a/Sources/LiveViewNativeCharts/ChartContent/RuleMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/RuleMark.swift
@@ -11,36 +11,36 @@ import LiveViewNative
 
 /// A mark that draws a horizontal or vertical line.
 ///
-/// Create a horizontal line by providing the `y` attribute, and optionally an `x-start`/`x-end`.
+/// Create a horizontal line by providing the `y` attribute, and optionally an `xStart`/`xEnd`.
 ///
 /// ```html
 /// <RuleMark
-///   y={5.8}
 ///   y:label="Minimum Height"
+///   y:value={5.8}
 /// />
 /// ```
 ///
-/// Create a vertical line by providing the `x` attribute, and optionally a `y-start`/`y-end`.
+/// Create a vertical line by providing the `x` attribute, and optionally a `yStart`/`yEnd`.
 ///
 /// ```html
 /// <RuleMark
-///   x={2.5}
 ///   x:label="Start Time"
+///   x:value={2.5}
 ///
-///   y-start={1}
-///   y-start:label="Start of Week"
-///   y-end={5}
-///   y-end:label="End of Week"
+///   yStart:label="Start of Week"
+///   yStart:value={1}
+///   yEnd:label="End of Week"
+///   yEnd:value={5}
 /// />
 /// ```
 ///
 /// ## Attributes
 /// * `x`
 /// * `y`
-/// * `x-start`
-/// * `x-end`
-/// * `y-start`
-/// * `y-end`
+/// * `xStart`
+/// * `xEnd`
+/// * `yStart`
+/// * `yEnd`
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/ConfiguringAxes.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/ConfiguringAxes.md
@@ -8,12 +8,20 @@ An axis mark can be used within the ``AxisMarks`` element.
 This element is used as the content of the ``ChartXAxisModifier`` and ``ChartYAxisModifier`` modifiers.
 
 ```html
-<Chart modifiers={chart_x_axis(@native, content: :my_axes)}>
+<Chart class="my-x-axis">
   ...
   <AxisMarks template={:my_axes}>
     <AxisGridLine />
   </AxisMarks>
 </Chart>
+```
+
+```elixir
+~SHEET"""
+"my-x-axis" do
+  chartXAxis(content: :my_axes)
+end
+"""
 ```
 
 Axis marks can be customized with modifiers.

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
@@ -62,11 +62,11 @@ defmodule MyAppWeb.ChartLive do
       <BarMark
         :for={item <- @data}
         
-        x={item.department}
         x:label="Department"
+        x:value={item.department}
 
-        y={item.profit}
         y:label="Profit"
+        y:value={item.profit}
 
         modifiers={@native |> foreground_style(value: {"Product Category", item.product_category})}
       />

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
@@ -1,86 +1,66 @@
 # ``LiveViewNativeCharts``
 
-`liveview-native-swiftui-charts` is an add-on library for LiveView Native. It adds Swift Charts support for data visualization.
+`liveview-native-swiftui-charts` is an add-on library for [LiveView Native](https://github.com/liveview-native/live_view_native). It adds [Swift Charts](https://developer.apple.com/documentation/charts) support for data visualization.
 
 ## Usage
 
-Add this library as a package to your LiveView Native application's Xcode project using its repo URL. Then, create an `AggregateRegistry` to include the provided `ChartsRegistry` within your native app builds:
+Import `LiveViewNativeCharts` and add the `ChartsRegistry` to the list of addons on your `LiveView`:
 
-```diff
+```swift
 import SwiftUI
 import LiveViewNative
-+ import LiveViewNativeCharts
-+ 
-+ struct MyRegistry: CustomRegistry {
-+     typealias Root = AppRegistries
-+ }
-+ 
-+ struct AppRegistries: AggregateRegistry {
-+     #Registries<
-+         MyRegistry,
-+         ChartsRegistry<Self>
-+     >
-+ }
+import LiveViewNativeCharts
 
-@MainActor
 struct ContentView: View {
--     @StateObject private var session: LiveSessionCoordinator<EmptyRegistry> = {
-+     @StateObject private var session: LiveSessionCoordinator<AppRegistries> = {
-        var config = LiveSessionConfiguration()
-        config.navigationMode = .enabled
-        
-        return LiveSessionCoordinator(URL(string: "http://localhost:4000/")!, config: config)
-    }()
-
     var body: some View {
-        LiveView(session: session)
+        #LiveView(
+            .localhost,
+            addons: [ChartsRegistry<_>.self]
+        )
     }
 }
 ```
 
-To render a chart within a SwiftUI HEEx template, use the `Chart` element.
-Include mark elements within the chart to display some data:
+Now you can use the `Chart` element in your template.
 
-```elixir
-defmodule MyAppWeb.ChartLive do
-  use Phoenix.LiveView
-  use LiveViewNative.LiveView
+<table>
 
-  def mount(_params, _session, socket) do
-    {:ok, assign(socket, data: [
-      %{ department: "Production", profit: 4000, product_category: "Gizmos" },
-      %{ department: "Marketing", profit: 2000, product_category: "Gizmos" },
-      %{ department: "Finance", profit: 2000, product_category: "Gizmos" },
-      ...
-    ])}
-  end
+<tr>
+<td>
 
-  @impl true
-  def render(%{platform_id: :swiftui} = assigns) do
-    ~Z"""
-    <Chart>
-      <BarMark
-        :for={item <- @data}
-        
-        x:label="Department"
-        x:value={item.department}
+```heex
+<Chart>
+  <BarMark
+    :for={item <- @data}
 
-        y:label="Profit"
-        y:value={item.profit}
+    x:label="Department"
+    x:value={item.department}
 
-        modifiers={@native |> foreground_style(value: {"Product Category", item.product_category})}
-      />
-    </Chart>
-    """swiftui
-  end
+    y:label="Profit"
+    y:value={item.profit}
+
+    class="fg-product-category"
+    product-category={item.product_category}
+  />
+</Chart>
+```
+```ex
+~SHEET"""
+"fg-product-category" do
+  foregroundStyle(by: .value("Product Category", attr("product-category")))
 end
+"""
 ```
 
-## Learn more
+</td>
 
-  * Official website: https://native.live
-  * Docs: https://hexdocs.pm/live_view_native_platform
-  * Source: https://github.com/liveviewnative/live_view_native_platform
+<td>
+<img src="./docs/example.png" alt="LiveView Native Charts screenshot" width="300" />
+</td>
+
+</tr>
+
+</table>
 
 ## Topics
 ### Elements

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Marks.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/Marks.md
@@ -14,11 +14,11 @@ If no label is provided, it is assumed to be a fixed numeric value.
 ```html
 <%= for item <- @data do %>
   <BarMark
-    x={item.department}
     x:label="Department"
+    x:value={item.department}
 
-    y={item.profit}
     y:label="Profit"
+    y:value={item.profit}
   />
 <% end %>
 ```

--- a/Sources/LiveViewNativeCharts/Modifiers/ForegroundStyleModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ForegroundStyleModifier.swift
@@ -43,7 +43,7 @@ struct ForegroundStyleModifier: ContentModifier {
             return unbox(
                 content: content,
                 label: value.label,
-                value.value.resolve(on: element),
+                value.value.resolve(on: element).value,
                 on: element,
                 in: context
             )

--- a/Sources/LiveViewNativeCharts/Modifiers/SymbolModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/SymbolModifier.swift
@@ -41,7 +41,7 @@ enum SymbolModifier: ContentModifier {
         case .shape(let shape):
             return content.symbol(shape)
         case .value(let value):
-            return unbox(content: content, label: value.label, value.value.resolve(on: element), on: element, in: context)
+            return unbox(content: content, label: value.label, value.value.resolve(on: element).value, on: element, in: context)
         case .view(let view):
             return content
                 .symbol {

--- a/Sources/LiveViewNativeCharts/Modifiers/SymbolSizeModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/SymbolSizeModifier.swift
@@ -43,7 +43,7 @@ struct SymbolSizeModifier: ContentModifier {
     ) -> Builder.Content {
         switch storage {
         case let .value(value):
-            return unbox(content: content, label: value.label, value.value.resolve(on: element), on: element, in: context)
+            return unbox(content: content, label: value.label, value.value.resolve(on: element).value, on: element, in: context)
         case let .area(area):
             return content.symbolSize(area)
         case let .size(size):

--- a/Sources/LiveViewNativeCharts/Views/Chart.swift
+++ b/Sources/LiveViewNativeCharts/Views/Chart.swift
@@ -16,18 +16,27 @@ import Charts
 ///
 /// ```html
 /// <Chart>
-///   <%= for item <- @data do %>
-///     <BarMark
-///       x={item.department}
-///       x:label="Department"
+///   <BarMark
+///     :for={item <- @data}
 ///
-///       y={item.profit}
-///       y:label="Profit"
+///     x:label="Department"
+///     x:value={item.department}
 ///
-///       modifiers={@native |> foreground_style(value: {"Product Category", item.product_category})}
-///     />
-///   <% end %>
+///     y:label="Profit"
+///     y:value={item.profit}
+///
+///     class="fg-product-category"
+///     product-category={item.product_category}
+///   />
 /// </Chart>
+/// ```
+///
+/// ```elixir
+/// ~SHEET""
+/// "fg-product-category" do
+///   foregroundStyle(by: .value("Product Category", attr("product-category")))
+/// end
+/// """
 /// ```
 ///
 /// - Note: Only some elements, such as marks, can be used in the content of a chart. Other types of elements are not supported.

--- a/Tests/LiveViewNativeChartsTests/LiveViewNativeChartsTests.swift
+++ b/Tests/LiveViewNativeChartsTests/LiveViewNativeChartsTests.swift
@@ -52,8 +52,8 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testSimpleChart() async throws {
         try await assertMatch(
             #"""
-            <BarMark x="0" x:label="X" y="0" y:label="Y" />
-            <BarMark x="1" x:label="X" y="1" y:label="Y" />
+            <BarMark x:value="0" x:label="X" y:value="0" y:label="Y" />
+            <BarMark x:value="1" x:label="X" y:value="1" y:label="Y" />
             """#
         ) {
             BarMark(x: .value("X", 0.0), y: .value("Y", 0.0))
@@ -64,7 +64,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testAreaMark() async throws {
         try await assertMatch(
             SampleData.scalar.map {
-                #"<AreaMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" />"#
+                #"<AreaMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.scalar, id: \.x) {
@@ -74,7 +74,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // series
         try await assertMatch(
             SampleData.series.map {
-                #"<AreaMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" series="\#($0.series)" series:label="Series" />"#
+                #"<AreaMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" series:value="\#($0.series)" series:label="Series" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(Array(SampleData.series.enumerated()), id: \.offset) { (_, element) in
@@ -84,7 +84,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // range
         try await assertMatch(
             SampleData.range.map {
-                #"<AreaMark x="\#($0.x)" x:label="X" y-start="\#($0.yStart)" y-start:label="Y Start" y-end="\#($0.yEnd)" y-end:label="Y End" />"#
+                #"<AreaMark x:value="\#($0.x)" x:label="X" yStart:value="\#($0.yStart)" yStart:label="Y Start" yEnd:value="\#($0.yEnd)" yEnd:label="Y End" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.range, id: \.x) {
@@ -94,7 +94,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // seriesRange
         try await assertMatch(
             SampleData.seriesRange.map {
-                #"<AreaMark x="\#($0.x)" x:label="X" y-start="\#($0.yStart)" y-start:label="Y Start" y-end="\#($0.yEnd)" y-end:label="Y End" series="\#($0.series)" series:label="Series" />"#
+                #"<AreaMark x:value="\#($0.x)" x:label="X" yStart:value="\#($0.yStart)" yStart:label="Y Start" yEnd:value="\#($0.yEnd)" yEnd:label="Y End" series="\#($0.series)" series:label="Series" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(Array(SampleData.seriesRange.enumerated()), id: \.offset) { (_, element) in
@@ -106,7 +106,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testBarMark() async throws {
         try await assertMatch(
             SampleData.scalar.map {
-                #"<BarMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" />"#
+                #"<BarMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.scalar, id: \.x) {
@@ -116,7 +116,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // range
         try await assertMatch(
             SampleData.range.map {
-                #"<BarMark x="\#($0.x)" x:label="X" y-start="\#($0.yStart)" y-start:label="Y Start" y-end="\#($0.yEnd)" y-end:label="Y End" />"#
+                #"<BarMark x:value="\#($0.x)" x:label="X" yStart:value="\#($0.yStart)" yStart:label="Y Start" yEnd:value="\#($0.yEnd)" yEnd:label="Y End" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.range, id: \.x) {
@@ -128,7 +128,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testLineMark() async throws {
         try await assertMatch(
             SampleData.scalar.map {
-                #"<LineMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" />"#
+                #"<LineMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.scalar, id: \.x) {
@@ -138,7 +138,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // series
         try await assertMatch(
             SampleData.series.map {
-                #"<LineMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" series="\#($0.series)" series:label="Series" />"#
+                #"<LineMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" series:value="\#($0.series)" series:label="Series" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(Array(SampleData.series.enumerated()), id: \.offset) { (_, element) in
@@ -150,7 +150,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testPointMark() async throws {
         try await assertMatch(
             SampleData.scalar.map {
-                #"<PointMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" />"#
+                #"<PointMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.scalar, id: \.x) {
@@ -162,7 +162,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
     func testRectangleMark() async throws {
         try await assertMatch(
             SampleData.scalar.map {
-                #"<RectangleMark x="\#($0.x)" x:label="X" y="\#($0.y)" y:label="Y" />"#
+                #"<RectangleMark x:value="\#($0.x)" x:label="X" y:value="\#($0.y)" y:label="Y" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.scalar, id: \.x) {
@@ -172,7 +172,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // range
         try await assertMatch(
             SampleData.range.map {
-                #"<RectangleMark x="\#($0.x)" x:label="X" y-start="\#($0.yStart)" y-start:label="Y Start" y-end="\#($0.yEnd)" y-end:label="Y End" />"#
+                #"<RectangleMark x:value="\#($0.x)" x:label="X" yStart:value="\#($0.yStart)" yStart:label="Y Start" yEnd:value="\#($0.yEnd)" yEnd:label="Y End" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.range, id: \.x) {
@@ -185,7 +185,7 @@ final class LiveViewNativeChartsTests: XCTestCase {
         // range
         try await assertMatch(
             SampleData.range.map {
-                #"<RuleMark x="\#($0.x)" x:label="X" y-start="\#($0.yStart)" y-start:label="Y Start" y-end="\#($0.yEnd)" y-end:label="Y End" />"#
+                #"<RuleMark x:value="\#($0.x)" x:label="X" yStart:value="\#($0.yStart)" yStart:label="Y Start" yEnd:value="\#($0.yEnd)" yEnd:label="Y End" />"#
             }.joined(separator: "\n")
         ) {
             ForEach(SampleData.range, id: \.x) {


### PR DESCRIPTION
* Added `value` for plottable values: `x={...} x:label="..."` becomes `x:value={...} x:label="..."`
* Attributes were changed to camel case
* README updates
* Fixes a crash with `AttributeReference` resolution for `AnyPlottable`
* Updated documentation to use stylesheets