### PR TITLE
Use `@Addon` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-Import `LiveViewNativeCharts` and add the `ChartsRegistry` to the list of addons on your `LiveView`:
+Import `LiveViewNativeCharts` and add `.charts` to the list of addons on your `LiveView`:
 
 ```swift
 import SwiftUI
@@ -21,7 +21,7 @@ struct ContentView: View {
     var body: some View {
         #LiveView(
             .localhost,
-            addons: [ChartsRegistry<_>.self]
+            addons: [.charts]
         )
     }
 }

--- a/Sources/LiveViewNativeCharts/ChartsRegistry.swift
+++ b/Sources/LiveViewNativeCharts/ChartsRegistry.swift
@@ -10,55 +10,58 @@ import SwiftUI
 import LiveViewNative
 import LiveViewNativeStylesheet
 
-/// Swift Charts add-on library registry.
-///
-/// Include this registry in your `AggregateRegistry` to gain access to the ``Chart`` view.
-public struct ChartsRegistry<Root: RootRegistry>: CustomRegistry {
-    public enum TagName: String {
-        case chart = "Chart"
-    }
-    
-    public static func lookup(_ name: TagName, element: ElementNode) -> some View {
-        switch name {
-        case .chart:
-            Chart<Root>()
+public extension Addons {
+    /// Swift Charts add-on library registry.
+    ///
+    /// Include this registry in your `AggregateRegistry` to gain access to the ``Chart`` view.
+    @Addon
+    public struct Charts<Root: RootRegistry> {
+        public enum TagName: String {
+            case chart = "Chart"
         }
-    }
-    
-    public struct CustomModifier: ViewModifier, ParseableModifierValue {
-        enum Storage {
-            case chartBackground(ChartBackgroundModifier<Root>)
-            case chartOverlay(ChartOverlayModifier<Root>)
-            case chartXAxis(ChartXAxisModifier<Root>)
-            case chartYAxis(ChartYAxisModifier<Root>)
-            case noop
-        }
-        let storage: Storage
         
-        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-            CustomModifierGroupParser(output: Self.self) {
-                ChartBackgroundModifier<Root>.parser(in: context).map({ Self(storage: .chartBackground($0)) })
-                ChartOverlayModifier<Root>.parser(in: context).map({ Self(storage: .chartOverlay($0)) })
-                ChartXAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartXAxis($0)) })
-                ChartYAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartYAxis($0)) })
-                ChartContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
-                AxisContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
-                AxisMarkBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+        public static func lookup(_ name: TagName, element: ElementNode) -> some View {
+            switch name {
+            case .chart:
+                Chart<Root>()
             }
         }
         
-        public func body(content: Content) -> some View {
-            switch storage {
-            case .chartBackground(let modifier):
-                content.modifier(modifier)
-            case .chartOverlay(let modifier):
-                content.modifier(modifier)
-            case .chartXAxis(let modifier):
-                content.modifier(modifier)
-            case .chartYAxis(let modifier):
-                content.modifier(modifier)
-            case .noop:
-                content
+        public struct CustomModifier: ViewModifier, ParseableModifierValue {
+            enum Storage {
+                case chartBackground(ChartBackgroundModifier<Root>)
+                case chartOverlay(ChartOverlayModifier<Root>)
+                case chartXAxis(ChartXAxisModifier<Root>)
+                case chartYAxis(ChartYAxisModifier<Root>)
+                case noop
+            }
+            let storage: Storage
+            
+            public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+                CustomModifierGroupParser(output: Self.self) {
+                    ChartBackgroundModifier<Root>.parser(in: context).map({ Self(storage: .chartBackground($0)) })
+                    ChartOverlayModifier<Root>.parser(in: context).map({ Self(storage: .chartOverlay($0)) })
+                    ChartXAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartXAxis($0)) })
+                    ChartYAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartYAxis($0)) })
+                    ChartContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+                    AxisContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+                    AxisMarkBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+                }
+            }
+            
+            public func body(content: Content) -> some View {
+                switch storage {
+                case .chartBackground(let modifier):
+                    content.modifier(modifier)
+                case .chartOverlay(let modifier):
+                    content.modifier(modifier)
+                case .chartXAxis(let modifier):
+                    content.modifier(modifier)
+                case .chartYAxis(let modifier):
+                    content.modifier(modifier)
+                case .noop:
+                    content
+                }
             }
         }
     }

--- a/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
+++ b/Sources/LiveViewNativeCharts/LiveViewNativeCharts.docc/LiveViewNativeCharts.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Import `LiveViewNativeCharts` and add the `ChartsRegistry` to the list of addons on your `LiveView`:
+Import `LiveViewNativeCharts` and add `.charts` to the list of addons on your `LiveView`:
 
 ```swift
 import SwiftUI
@@ -15,7 +15,7 @@ struct ContentView: View {
     var body: some View {
         #LiveView(
             .localhost,
-            addons: [ChartsRegistry<_>.self]
+            addons: [.charts]
         )
     }
 }


### PR DESCRIPTION
Currently, the `@Addon` macro is only available on the `main` branch of `liveview-client-swiftui`. This should depend on a specific release instead before merging.