### PR TITLE
Fix crash when decoding attributes, add `chartLegend`

### DIFF
--- a/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
+++ b/Sources/LiveViewNativeCharts/AxisContent/AxisMarks.swift
@@ -140,7 +140,7 @@ struct AxisMarks<R: RootRegistry>: ComposedAxisContent {
                 .compactMap {
                     try? $0.attributes
                         .first(where: { $0.name == "value" })
-                        .map(Double.init)
+                        .map({ try Double.init(from: $0, on: element) })
                 }
             Charts.AxisMarks(preset: preset, position: position, values: values) { (value: Charts.AxisValue) in
                 AnyAxisMark(
@@ -148,7 +148,8 @@ struct AxisMarks<R: RootRegistry>: ComposedAxisContent {
                         children.filter({
                             (try? $0.attributes
                                 .first(where: { $0.name == "value" })
-                                .map(Double.init))
+                                .map({ try Double.init(from: $0, on: element) })
+                            )
                             == value.as(Double.self)
                         }),
                         with: AxisMarkBuilder.self,
@@ -297,30 +298,30 @@ extension AxisMarkValues {
                 if let minimumStride = try? element.attributeValue(Double.self, for: "minimum-stride") {
                     self = .automatic(
                         minimumStride: minimumStride,
-                        desiredCount: try? element.attributeValue(Int.self, for: "desired-count"),
-                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
+                        desiredCount: try? element.attributeValue(Int.self, for: "desiredCount"),
+                        roundLowerBound: element.attributeBoolean(for: "roundLowerBound"),
+                        roundUpperBound: element.attributeBoolean(for: "roundUpperBound")
                     )
                 } else {
                     self = .automatic(
-                        desiredCount: try? element.attributeValue(Int.self, for: "desired-count"),
-                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
+                        desiredCount: try? element.attributeValue(Int.self, for: "desiredCount"),
+                        roundLowerBound: element.attributeBoolean(for: "roundLowerBound"),
+                        roundUpperBound: element.attributeBoolean(for: "roundUpperBound")
                     )
                 }
             case "stride":
                 if let numeric = try? element.attributeValue(Double.self, for: "stride") {
                     self = .stride(
                         by: numeric,
-                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound")
+                        roundLowerBound: element.attributeBoolean(for: "roundLowerBound"),
+                        roundUpperBound: element.attributeBoolean(for: "roundUpperBound")
                     )
                 } else if let component = try? element.attributeValue(Calendar.Component.self, for: "stride") {
                     self = .stride(
                         by: component,
                         count: (try? element.attributeValue(Int.self, for: "count")) ?? 1,
-                        roundLowerBound: element.attributeBoolean(for: "round-lower-bound"),
-                        roundUpperBound: element.attributeBoolean(for: "round-upper-bound"),
+                        roundLowerBound: element.attributeBoolean(for: "roundLowerBound"),
+                        roundUpperBound: element.attributeBoolean(for: "roundUpperBound"),
                         calendar: (try? element.attributeValue(Calendar.Identifier.self, for: "calendar")).flatMap(Calendar.init(identifier:))
                     )
                 }
@@ -430,7 +431,7 @@ extension Calendar.Identifier: AttributeDecodable {
 }
 
 extension StrokeStyle: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
-        self = .init(lineWidth: try Double(from: attribute))
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
+        self = .init(lineWidth: try Double(from: attribute, on: element))
     }
 }

--- a/Sources/LiveViewNativeCharts/ChartContent/AnyMark.swift
+++ b/Sources/LiveViewNativeCharts/ChartContent/AnyMark.swift
@@ -121,32 +121,20 @@ struct AnyMark<M: MarkProtocol>: ChartContent {
         let x = element.plottable(named: "x")
         let y = element.plottable(named: "y")
         
-        let fixedX = element.attributeValue(for: "x")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
-        let fixedY = element.attributeValue(for: "y")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
+        let fixedX = try? element.attributeValue(CGFloat.self, for: "x")
+        let fixedY = try? element.attributeValue(CGFloat.self, for: "y")
         
         let xStart = element.plottable(named: "xStart")
         let xEnd = element.plottable(named: "xEnd")
         
-        let fixedXStart = element.attributeValue(for: "xStart")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
-        let fixedXEnd = element.attributeValue(for: "xEnd")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
+        let fixedXStart = try? element.attributeValue(CGFloat.self, for: "xStart")
+        let fixedXEnd = try? element.attributeValue(CGFloat.self, for: "xEnd")
         
         let yStart = element.plottable(named: "yStart")
         let yEnd = element.plottable(named: "yEnd")
         
-        let fixedYStart = element.attributeValue(for: "yStart")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
-        let fixedYEnd = element.attributeValue(for: "yEnd")
-            .flatMap(Double.init(_:))
-            .flatMap(CGFloat.init(_:))
+        let fixedYStart = try? element.attributeValue(CGFloat.self, for: "yStart")
+        let fixedYEnd = try? element.attributeValue(CGFloat.self, for: "yEnd")
         
         let series = element.plottable(named: "series")
         

--- a/Sources/LiveViewNativeCharts/ChartsRegistry.swift
+++ b/Sources/LiveViewNativeCharts/ChartsRegistry.swift
@@ -30,6 +30,7 @@ public extension Addons {
         public struct CustomModifier: ViewModifier, ParseableModifierValue {
             enum Storage {
                 case chartBackground(ChartBackgroundModifier<Root>)
+                case chartLegend(ChartLegendModifier<Root>)
                 case chartOverlay(ChartOverlayModifier<Root>)
                 case chartXAxis(ChartXAxisModifier<Root>)
                 case chartYAxis(ChartYAxisModifier<Root>)
@@ -40,6 +41,7 @@ public extension Addons {
             public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
                 CustomModifierGroupParser(output: Self.self) {
                     ChartBackgroundModifier<Root>.parser(in: context).map({ Self(storage: .chartBackground($0)) })
+                    ChartLegendModifier<Root>.parser(in: context).map({ Self(storage: .chartLegend($0)) })
                     ChartOverlayModifier<Root>.parser(in: context).map({ Self(storage: .chartOverlay($0)) })
                     ChartXAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartXAxis($0)) })
                     ChartYAxisModifier<Root>.parser(in: context).map({ Self(storage: .chartYAxis($0)) })
@@ -52,6 +54,8 @@ public extension Addons {
             public func body(content: Content) -> some View {
                 switch storage {
                 case .chartBackground(let modifier):
+                    content.modifier(modifier)
+                case .chartLegend(let modifier):
                     content.modifier(modifier)
                 case .chartOverlay(let modifier):
                     content.modifier(modifier)

--- a/Sources/LiveViewNativeCharts/Modifiers/ChartLegendModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ChartLegendModifier.swift
@@ -1,0 +1,78 @@
+//
+//  ChartLegendModifier.swift
+//
+//
+//  Created by Carson Katri on 5/16/24.
+//
+
+import Charts
+import SwiftUI
+import LiveViewNative
+import LiveViewNativeStylesheet
+
+@ParseableExpression
+struct ChartLegendModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "chartLegend" }
+    
+    enum Storage {
+        case visibility(Visibility)
+        case content(
+            position: AnnotationPosition,
+            alignment: Alignment?,
+            spacing: CGFloat?,
+            content: ViewReference
+        )
+        case position(
+            position: AnnotationPosition,
+            alignment: Alignment?,
+            spacing: CGFloat?
+        )
+    }
+    let storage: Storage
+    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+    init(_ visibility: Visibility) {
+        self.storage = .visibility(visibility)
+    }
+    
+    init(
+        position: AnnotationPosition = .automatic,
+        alignment: Alignment? = nil,
+        spacing: CGFloat? = nil,
+        content: ViewReference
+    ) {
+        self.storage = .content(
+            position: position,
+            alignment: alignment,
+            spacing: spacing,
+            content: content
+        )
+    }
+    
+    init(
+        position: AnnotationPosition = .automatic,
+        alignment: Alignment? = nil,
+        spacing: CGFloat? = nil
+    ) {
+        self.storage = .position(
+            position: position,
+            alignment: alignment,
+            spacing: spacing
+        )
+    }
+    
+    func body(content: Content) -> some View {
+        switch self.storage {
+        case let .visibility(visibility):
+            content.chartLegend(visibility)
+        case let .content(position, alignment, spacing, _content):
+            content.chartLegend(position: position, alignment: alignment, spacing: spacing) {
+                _content.resolve(on: element, in: context)
+            }
+        case let .position(position, alignment, spacing):
+            content.chartLegend(position: position, alignment: alignment, spacing: spacing)
+        }
+    }
+}

--- a/Sources/LiveViewNativeCharts/Types/AnnotationPosition.swift
+++ b/Sources/LiveViewNativeCharts/Types/AnnotationPosition.swift
@@ -1,0 +1,39 @@
+//
+//  AnnotationPosition.swift
+//
+//
+//  Created by Carson Katri on 5/16/24.
+//
+
+import Charts
+import LiveViewNativeStylesheet
+
+/// See [`Charts.AnnotationPosition`](https://developer.apple.com/documentation/charts/AnnotationPosition) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.overlay`
+/// * `.top`
+/// * `.bottom`
+/// * `.leading`
+/// * `.trailing`
+/// * `.topLeading`
+/// * `.topTrailing`
+/// * `.bottomLeading`
+/// * `.bottomTrailing`
+extension AnnotationPosition: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "automatic": .automatic,
+            "overlay": .overlay,
+            "top": .top,
+            "bottom": .bottom,
+            "leading": .leading,
+            "trailing": .trailing,
+            "topLeading": .topLeading,
+            "topTrailing": .topTrailing,
+            "bottomLeading": .bottomLeading,
+            "bottomTrailing": .bottomTrailing,
+        ])
+    }
+}


### PR DESCRIPTION
Fixes an issue where attribute decoding for `AxisMarks` would crash.

Also includes the `chartLegend` modifier.