### PR TITLE
Concurrency-related compile fix for 0.4.0 branch

### DIFF
--- a/Sources/LiveViewNativeCharts/Modifiers/ChartLegendModifier.swift
+++ b/Sources/LiveViewNativeCharts/Modifiers/ChartLegendModifier.swift
@@ -38,13 +38,13 @@ struct ChartLegendModifier<R: RootRegistry>: ViewModifier, @preconcurrency Decod
     
     @MainActor
     init(
-        position: AttributeReference<AnnotationPosition.Resolvable> = .constant(.automatic),
+        position: AttributeReference<AnnotationPosition.Resolvable>? = nil,
         alignment: Alignment.Resolvable? = nil,
         spacing: CGFloat.Resolvable? = nil,
         content: ViewReference
     ) {
         self.storage = .content(
-            position: position,
+            position: position ?? .constant(.automatic),
             alignment: alignment,
             spacing: spacing,
             content: content
@@ -53,12 +53,12 @@ struct ChartLegendModifier<R: RootRegistry>: ViewModifier, @preconcurrency Decod
     
     @MainActor
     init(
-        position: AttributeReference<AnnotationPosition.Resolvable> = .constant(.automatic),
+        position: AttributeReference<AnnotationPosition.Resolvable>? = nil,
         alignment: Alignment.Resolvable? = nil,
         spacing: CGFloat.Resolvable? = nil
     ) {
         self.storage = .position(
-            position: position,
+            position: position ?? .constant(.automatic),
             alignment: alignment,
             spacing: spacing
         )


### PR DESCRIPTION
Compile fix for this error:

> ChartLegendModifier.swift:41:72: Call to main actor-isolated static method 'constant' in a synchronous nonisolated context

Can't use MainActor-isolated values as defaults for parameters, as those will use the caller's isolation context, which isn't guaranteed to be on the MainActor, even if the function is annotated as `@MainActor`.